### PR TITLE
🍮 Support for custom registries

### DIFF
--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -63,6 +63,7 @@ fn main() -> anyhow::Result<()> {
             no_dependencies,
             no_isolate_dependencies_from_breaking_changes,
             capitalize_commit,
+            registry
         } => {
             let verbose = execute || verbose;
             init_logging(verbose);
@@ -90,6 +91,7 @@ fn main() -> anyhow::Result<()> {
                     changelog_links: !no_changelog_links,
                     allow_changelog_github_release: !no_changelog_github_release,
                     capitalize_commit,
+                    registry
                 },
                 crates,
                 to_bump_spec(bump.as_deref().unwrap_or(DEFAULT_BUMP_SPEC))?,

--- a/src/cli/options.rs
+++ b/src/cli/options.rs
@@ -161,6 +161,10 @@ pub enum SubCommands {
         /// Capitalize commit messages.
         #[clap(long, help_heading = Some("CHANGELOG"))]
         capitalize_commit: bool,
+
+        /// Alternative registry to publish to
+        #[clap(long, help_heading = Some("REGISTRY"))]
+        registry: Option<String>,
     },
     #[clap(name = "changelog", version = option_env!("CARGO_SMART_RELEASE_VERSION"))]
     /// Generate changelogs from commit histories, non-destructively.

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -1,7 +1,7 @@
 pub mod release {
     use crate::changelog::section::segment;
 
-    #[derive(Debug, Clone, Copy)]
+    #[derive(Debug, Clone)]
     pub struct Options {
         pub dry_run: bool,
         pub allow_dirty: bool,
@@ -26,6 +26,7 @@ pub mod release {
         pub changelog_links: bool,
         pub allow_changelog_github_release: bool,
         pub capitalize_commit: bool,
+        pub registry: Option<String>,
     }
 }
 #[path = "release/mod.rs"]

--- a/src/command/release/cargo.rs
+++ b/src/command/release/cargo.rs
@@ -16,6 +16,7 @@ pub(in crate::command::release_impl) fn publish_crate(
         allow_dirty,
         no_verify,
         verbose,
+        registry,
         ..
     }: Options,
 ) -> anyhow::Result<()> {
@@ -28,6 +29,10 @@ pub(in crate::command::release_impl) fn publish_crate(
     for attempt in 1..=max_attempts {
         let mut c = Command::new("cargo");
         c.arg("publish");
+
+        if let Some(ref registry) = registry {
+            c.arg("--registry").arg(registry);
+        }
 
         if allow_dirty {
             c.arg("--allow-dirty");

--- a/src/command/release/manifest.rs
+++ b/src/command/release/manifest.rs
@@ -42,7 +42,7 @@ pub(in crate::command::release_impl) fn edit_version_and_fixup_dependent_crates_
         release_section_by_publishee,
         mut made_change,
     } = changelog
-        .then(|| gather_changelog_data(ctx, &crates_and_versions_to_be_published, opts))
+        .then(|| gather_changelog_data(ctx, &crates_and_versions_to_be_published, opts.clone()))
         .transpose()?
         .unwrap_or_default();
 
@@ -72,7 +72,7 @@ pub(in crate::command::release_impl) fn edit_version_and_fixup_dependent_crates_
             possibly_new_version,
             &crates_with_version_change,
             lock,
-            opts,
+            opts.clone(),
         )?;
     }
 
@@ -88,10 +88,10 @@ pub(in crate::command::release_impl) fn edit_version_and_fixup_dependent_crates_
         would_stop_release,
         locks_by_manifest_path.len(),
         &pending_changelogs,
-        opts,
+        opts.clone(),
     );
 
-    preview_changelogs(ctx, &pending_changelogs, opts)?;
+    preview_changelogs(ctx, &pending_changelogs, opts.clone())?;
 
     let bail_message = commit_locks_and_generate_bail_message(
         ctx,
@@ -99,7 +99,7 @@ pub(in crate::command::release_impl) fn edit_version_and_fixup_dependent_crates_
         locks_by_manifest_path,
         changelog_ids_with_statistical_segments_only,
         changelog_ids_probably_lacking_user_edits,
-        opts,
+        opts.clone(),
     )?;
 
     let res = git::commit_changes(commit_message, dry_run, !made_change, &ctx.base)?;


### PR DESCRIPTION
I've added the option to publish to different (custom) registries such as for example cloudsmith.

This required removing the `Copy` derive from the `Options` struct because `Option<String>` isn't trivially copy-able, so I had to introduce quite a few `.clone()` calls as well unfortunately.