### PR TITLE
fix use of span to get number of days

### DIFF
--- a/src/changelog/section/segment.rs
+++ b/src/changelog/section/segment.rs
@@ -109,14 +109,14 @@ impl Details {
 pub struct CommitStatistics {
     /// Amount of commits that contributed to the release
     pub count: usize,
-    /// The time span from first to last commit, if there is more than one.
-    pub duration: Option<jiff::Span>,
+    /// The time span, in days, from first to last commit, if there is more than one.
+    pub duration: Option<i32>,
     /// Amount of commits that could be parsed as git-conventional
     pub conventional_count: usize,
     /// The issue numbers that were referenced in commit messages
     pub unique_issues: Vec<details::Category>,
-    /// The duration from the release before this one, if this isn't the first release.
-    pub time_passed_since_last_release: Option<jiff::Span>,
+    /// The duration, in days, from the release before this one, if this isn't the first release.
+    pub time_passed_since_last_release: Option<i32>,
 }
 
 impl CommitStatistics {

--- a/src/changelog/write.rs
+++ b/src/changelog/write.rs
@@ -320,19 +320,15 @@ impl section::Segment {
                     count,
                     if *count == 1 { "commit" } else { "commits" },
                     match duration {
-                        Some(duration) if duration.get_days() > 0 => format!(
+                        &Some(duration) if duration > 0 => format!(
                             " over the course of {} calendar {}.",
-                            duration.get_days(),
-                            if duration.get_days() == 1 { "day" } else { "days" }
+                            duration,
+                            if duration == 1 { "day" } else { "days" }
                         ),
                         _ => ".".into(),
                     }
                 )?;
-                if let Some(days_between_releases) = time_passed_since_last_release
-                    .and_then(|d| d.total(jiff::Unit::Day).ok())
-                    .map(|d| d.floor() as u64)
-                    .filter(|d| *d > 0)
-                {
+                if let Some(days_between_releases) = time_passed_since_last_release.filter(|d| *d > 0) {
                     writeln!(
                         out,
                         " - {} {} passed between releases.",

--- a/tests/changelog/write_and_parse/mod.rs
+++ b/tests/changelog/write_and_parse/mod.rs
@@ -109,9 +109,9 @@ fn all_section_types_round_trips_lossy() -> Result {
                     section::Segment::Clippy(section::Data::Generated(section::segment::ThanksClippy { count: 42 })),
                     section::Segment::Statistics(section::Data::Generated(section::segment::CommitStatistics {
                         count: 100,
-                        duration: jiff::Span::new().days(32).into(),
+                        duration: Some(32),
                         conventional_count: 20,
-                        time_passed_since_last_release: Some(jiff::Span::new().days(60)),
+                        time_passed_since_last_release: Some(60),
                         unique_issues: vec![
                             section::segment::details::Category::Issue("1".into()),
                             section::segment::details::Category::Uncategorized,


### PR DESCRIPTION
This commit revises the change in #28 to be a bit more robust.

Originally, before #28, the code was buggy because, I think, `Span` was
being used like a normal "absolute" duration. But a `Span` keeps track
of values for each individual unit. It isn't just a single number of
nanoseconds like, e.g., `std::time::Duration` is. It's "smarter" than
that. It deals with non-uniform units like days, months and years. But
to do it correctly, you need a reference date.

What this means is that when you get a `Span` by subtracting two `Zoned`
values, you can't just ask the `Span` for the total number of days via
`get_days()`. It has to be *computed*. In #28, this was done for one
case but not the other via the `Span::total` API. While this works
today, the code was not providing a reference date, which means days are
silently treated as always being 24 hours long.
See https://github.com/BurntSushi/jiff/issues/48 for more details where
it's likely that this sort of usage will return an error in `jiff 0.2`.

The main gotcha here is that since this is using `gix::date`, the
`Zoned` values that are created are just "fixed offset" datetimes. They
don't actually have a time zone. So in practice, such datetimes will
always have all days be 24 hours long. This is not correct, but it's not
clear to me that this is fixable inside the context of `git`. But at
least with this patch, if you do ever end up using true time zones, then
this code will be robust to that.
