### PR TITLE
feat: Add option to signoff git commits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,6 +174,7 @@ dependencies = [
  "log",
  "pulldown-cmark",
  "semver",
+ "testing_logger",
  "toml_edit 0.21.1",
  "winnow 0.5.40",
 ]
@@ -2117,6 +2118,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "testing_logger"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d92b727cb45d33ae956f7f46b966b25f1bc712092aeef9dba5ac798fc89f720"
+dependencies = [
+ "log",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,5 +43,6 @@ bitflags = "2"
 [dev-dependencies]
 insta = "1.8.0"
 gix-testtools = "0.15.0"
+testing_logger = "0.1.1"
 
 [workspace]

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -63,6 +63,7 @@ fn main() -> anyhow::Result<()> {
             no_isolate_dependencies_from_breaking_changes,
             capitalize_commit,
             registry,
+            signoff,
         } => {
             let verbose = execute || verbose;
             init_logging(verbose);
@@ -91,6 +92,7 @@ fn main() -> anyhow::Result<()> {
                     allow_changelog_github_release: !no_changelog_github_release,
                     capitalize_commit,
                     registry,
+                    signoff,
                 },
                 crates,
                 to_bump_spec(bump.as_deref().unwrap_or(DEFAULT_BUMP_SPEC))?,

--- a/src/cli/options.rs
+++ b/src/cli/options.rs
@@ -165,6 +165,10 @@ pub enum SubCommands {
         /// Capitalize commit messages.
         #[clap(long, help_heading = Some("CHANGELOG"))]
         capitalize_commit: bool,
+
+        /// Sign off commit messages.
+        #[clap(long, help_heading = Some("CUSTOMIZATION"))]
+        signoff: bool,
     },
     #[clap(name = "changelog", version = option_env!("CARGO_SMART_RELEASE_VERSION"))]
     /// Generate changelogs from commit histories, non-destructively.

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -27,6 +27,7 @@ pub mod release {
         pub allow_changelog_github_release: bool,
         pub capitalize_commit: bool,
         pub registry: Option<String>,
+        pub signoff: bool,
     }
 }
 #[path = "release/mod.rs"]

--- a/src/command/release/manifest.rs
+++ b/src/command/release/manifest.rs
@@ -102,7 +102,7 @@ pub(in crate::command::release_impl) fn edit_version_and_fixup_dependent_crates_
         opts.clone(),
     )?;
 
-    let res = git::commit_changes(commit_message, dry_run, !made_change, &ctx.base)?;
+    let res = git::commit_changes(commit_message, dry_run, !made_change, opts.signoff, &ctx.base)?;
     if let Some(bail_message) = bail_message {
         bail!(bail_message);
     } else {


### PR DESCRIPTION
Adds `cargo smart-release --signoff` to sign off git commits.

Fixes: #31