### PR TITLE
Apply fixes for new clippy errors

### DIFF
--- a/src/changelog/parse.rs
+++ b/src/changelog/parse.rs
@@ -404,7 +404,7 @@ fn parse_message_id(html: &str) -> Option<gix::hash::ObjectId> {
             'a'..='f' | '0'..='9'
         )
     })?;
-    gix::hash::ObjectId::from_hex(html[..end_of_hex].as_bytes()).ok()
+    gix::hash::ObjectId::from_hex(&html.as_bytes()[..end_of_hex]).ok()
 }
 
 fn update_unknown_range(target: &mut Option<Range<usize>>, source: Range<usize>) {

--- a/src/changelog/write.rs
+++ b/src/changelog/write.rs
@@ -51,7 +51,7 @@ impl From<gix::Url> for RepositoryUrl {
 
 impl RepositoryUrl {
     pub fn is_github(&self) -> bool {
-        self.inner.host().map_or(false, |h| h == "github.com")
+        self.inner.host() == Some("github.com")
     }
 
     fn cleaned_path(&self) -> String {

--- a/src/command/release/manifest.rs
+++ b/src/command/release/manifest.rs
@@ -485,7 +485,7 @@ fn gather_changelog_data<'meta>(
                 capitalize_commit,
             )?;
             lock.with_mut(|file| file.write_all(write_buf.as_bytes()))?;
-            *made_change |= previous_content.map_or(true, |previous| write_buf != previous);
+            *made_change |= previous_content != Some(write_buf);
             pending_changelogs.push((publishee, log_init_state.is_modified(), lock));
             release_section_by_publishee.insert(publishee.name.as_str(), log.take_recent_release_section());
         }
@@ -546,7 +546,7 @@ fn set_version_and_update_package_dependency(
                     let force_update = conservative_pre_release_version_handling
                         && version::is_pre_release(new_version) // setting the lower bound unnecessarily can be harmful
                         // don't claim to be conservative if this is necessary anyway
-                        && req_as_version(&version_req).map_or(false, |req_version| !version::rhs_is_breaking_bump_for_lhs(&req_version, new_version));
+                        && req_as_version(&version_req).is_some_and(|req_version| !version::rhs_is_breaking_bump_for_lhs(&req_version, new_version));
                     if !version_req.matches(new_version) || force_update {
                         if !version_req_unset_or_default(&version_req) {
                             bail!(

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -55,11 +55,11 @@ pub fn is_top_level_package(manifest_path: &Utf8Path, repo: &gix::Repository) ->
                 .expect("cwd")
                 .join(repo.work_dir().as_ref().expect("repo with working tree")),
         )
-        .map_or(false, |p| p.components().count() == 1)
+        .is_ok_and(|p| p.components().count() == 1)
 }
 
 pub fn version_req_unset_or_default(req: &VersionReq) -> bool {
-    req.comparators.last().map_or(true, |comp| comp.op == semver::Op::Caret)
+    req.comparators.last().is_none_or(|comp| comp.op == semver::Op::Caret)
 }
 
 pub fn package_eq_dependency_ignore_dev_without_version(package: &Package, dependency: &Dependency) -> bool {
@@ -70,14 +70,14 @@ pub fn package_eq_dependency_ignore_dev_without_version(package: &Package, depen
 pub fn workspace_package_by_dependency<'a>(meta: &'a Metadata, dep: &Dependency) -> Option<&'a Package> {
     meta.packages
         .iter()
-        .find(|p| p.name == dep.name && p.source.as_ref().map_or(true, |s| !s.is_crates_io()))
+        .find(|p| p.name == dep.name && p.source.as_ref().is_none_or(|s| !s.is_crates_io()))
         .filter(|p| meta.workspace_members.iter().any(|m| m == &p.id))
 }
 
 pub fn package_by_name<'a>(meta: &'a Metadata, name: &str) -> anyhow::Result<&'a Package> {
     meta.packages
         .iter()
-        .find(|p| p.name == name && p.source.as_ref().map_or(true, |s| !s.is_crates_io()))
+        .find(|p| p.name == name && p.source.as_ref().is_none_or(|s| !s.is_crates_io()))
         .ok_or_else(|| anyhow!("workspace member '{}' must be a listed package", name))
 }
 

--- a/src/version.rs
+++ b/src/version.rs
@@ -116,11 +116,7 @@ pub(crate) fn bump_package_with_spec(
                 };
                 assert!(is_breaking, "BUG: breaking changes are…breaking :D");
                 is_breaking
-            } else if unreleased
-                .history
-                .iter()
-                .any(|item| item.message.kind.map_or(false, |kind| kind == "feat"))
-            {
+            } else if unreleased.history.iter().any(|item| item.message.kind == Some("feat")) {
                 let is_breaking = if is_pre_release(&v) {
                     bump_major_minor_patch(&mut v, Patch)
                 } else {


### PR DESCRIPTION
Since clippy was last run on CI, it detects more opportunities to simplify code. The `clippy` CI job is now failing on code where it had originally passed. This simplifies the code as clippy prefers.

Relating to #42, perhaps I should downcase my commit message here? But if #42 is merged before the next release of cargo-smart-release, then that may not be necessary.

---

I opened a few other pull requests which, like main if CI is rerun, fail due to the new clippy errors that this PR fixes. If this is merged, then I'd be pleased to rebase them onto main to fix their CI.