### PR TITLE
Recognize variants of "thanks clippy"

### DIFF
--- a/src/changelog/section/from_history.rs
+++ b/src/changelog/section/from_history.rs
@@ -130,7 +130,8 @@ impl Section {
             if selection.contains(Selection::CLIPPY) {
                 let count = history
                     .iter()
-                    .filter(|item| item.message.title.starts_with("thanks clippy"))
+                    .map(|item| item.message.title.to_lowercase())
+                    .filter(|title| title.starts_with("thanks clippy") || title.starts_with("thanks, clippy"))
                     .count();
                 if count > 0 {
                     segments.push(Segment::Clippy(section::Data::Generated(


### PR DESCRIPTION
Fixes #39

The commit message title (or title prefix) "thanks clippy" was recognized, but case variants such as "Thanks clippy" were not. Less importantly, the plausible "thanks, clippy" variant (and its case variants) were also not recognized.

This downcases the title before checking for "thanks clippy" as a prefix, and it adds a check for the prefix "thanks, clippy".

---

Currently this fails on CI due to new clippy errors, which are not specific to this PR and which #41 fixes. If #41 is merged then this could be rebased and I expect it would pass CI.

Entirely aside from that, I would guess that this may not yet ready to be merged, since it has no tests. The change is fairly simple, but it is plausible that there could be a bug. I didn't add a test yet, since it looks like this only has integration tests, and I'm not sure if or how a snapshot should be made with this, or if a narrower test should be added, or if the existing code in this area should be refactored to make it easier to test. Alternatively, if this is considered acceptable for merging without a test, then waiting to inquire about this might've incurred extra delays.

I considered using regular expressions. I don't know if acceptable to add dependencies for this purpose. But `regex-automata` is already [a transitive dependency through `bstr`](https://github.com/Byron/cargo-smart-release/blob/7db489e9d3df4f111d59f695b66c241955666509/Cargo.lock#L132-L141). I decided for now not to do that, since it seems more complicated than necessary, and I don't know if there is really value in matching things like `thanks   clippy`.

I don't know if this is a `fix:` or a `feat:`. I went with `feat:`.