### PR TITLE
Make CI workflows slightly more readable, usable, and maintainable

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+- package-ecosystem: github-actions
+  directory: '/'
+  schedule:
+    interval: monthly
+  groups:
+    github-actions:
+      patterns: ['*']

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -6,8 +6,8 @@ permissions:
 on:
   pull_request:
     paths:
-      - '**/Cargo.toml'
-      - '**/Cargo.lock'
+    - '**/Cargo.toml'
+    - '**/Cargo.lock'
   push:
     branches:
     - main
@@ -40,7 +40,7 @@ jobs:
     strategy:
       matrix:
         checks:
-          - bans licenses sources
+        - bans licenses sources
     steps:
     - uses: actions/checkout@v3
     - uses: EmbarkStudios/cargo-deny-action@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,9 @@ jobs:
     needs: [test, docs, rustfmt, clippy, installation]
     runs-on: ubuntu-latest
     steps:
-      - name: Done
-        run: exit 0
+    - name: Done
+      run: exit 0
+
   test:
     name: Test
     strategy:
@@ -46,6 +47,7 @@ jobs:
     - name: Journey
       if: ${{ matrix.os != 'windows-latest' }} # on windows, journey tests don't run yet and it's not important enough right now
       run: just ci-test
+
   installation:
     name: Installation
     strategy:
@@ -55,8 +57,9 @@ jobs:
     continue-on-error: ${{ matrix.rust != 'stable' }}
     runs-on: ${{ matrix.os }}
     steps:
-      - name: "Installation from crates.io: cargo-smart-release"
-        run: cargo install --debug --force cargo-smart-release
+    - name: "Installation from crates.io: cargo-smart-release"
+      run: cargo install --debug --force cargo-smart-release
+
   lockfile:
     runs-on: ubuntu-latest
     steps:
@@ -65,6 +68,7 @@ jobs:
     - uses: Swatinem/rust-cache@v2
     - name: "Is lockfile updated?"
       run: cargo fetch --locked
+
   docs:
     name: Docs
     runs-on: ubuntu-latest
@@ -76,6 +80,7 @@ jobs:
       env:
         RUSTDOCFLAGS: -D warnings
       run: cargo doc --workspace --all-features --no-deps --document-private-items
+
   rustfmt:
     name: rustfmt
     runs-on: ubuntu-latest
@@ -85,6 +90,7 @@ jobs:
     - uses: Swatinem/rust-cache@v2
     - name: Check formatting
       run: cargo fmt --all -- --check
+
   clippy:
     name: clippy
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
   push:
     branches:
     - main
+    - 'run-ci/**'
+    - '**/run-ci/**'
+  workflow_dispatch:
 
 env:
   RUST_BACKTRACE: 1

--- a/.github/workflows/rust-next.yml
+++ b/.github/workflows/rust-next.yml
@@ -38,6 +38,7 @@ jobs:
       run: cargo test --workspace --all-features
     - name: No-default features
       run: cargo test --workspace --no-default-features
+
   latest:
     name: "Check latest dependencies"
     runs-on: ubuntu-latest


### PR DESCRIPTION
This proposes a few improvements to CI workflows:

- Make whitespace style more consistent and, where no decisive style is present, more readable.
- Run the main CI workflow on the `push` trigger not just on `main` but also on branches with non-trailing `run-ci` components, to make it easier for people to run the workflow on feature branches in forks who wish to do so.
- Enable Dependabot grouped version updates, for GitHub Actions only (not Rust dependencies). A number of actions are in old major versions. I recommend also enabling Dependabot security updates (which are separate from version updates and are not limited to its cadence).

The commit messages have more information about each of these changes.

Currently, all new CI runs fail in the clippy job due to new clippy errors. #41 would fix that, so if #41 is merged, then this could be rebased onto main to make all tests pass.