### PR TITLE
Improve title in the contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to PROJECT
+# Contributing to cargo-smart-release
 
 Thanks for wanting to contribute! There are many ways to contribute so there
 should be something suitable for your time-budget.


### PR DESCRIPTION
Closes #40

The contributing guidelines, which originated from a template, were shortened and customized in 52f8824 (for #40), but the title was still the generic "Contributing to PROJECT". This fixes that.